### PR TITLE
Refaktoroitu VideoDaosta pois toistuvaa koodia

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # ohtu2017-miniprojekti
 
-
 [Definition of Done](https://github.com/OtterleyW/ohtu2017-miniprojekti/blob/master/definitionofdone.md)
 
 [Backlog](https://docs.google.com/spreadsheets/d/15L0jkI4aUTAlSz5wAOpp7wbPSEIVxaG1op6_wA98RLQ/edit?usp=sharing)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ohtu2017-miniprojekti
 
+
 [Definition of Done](https://github.com/OtterleyW/ohtu2017-miniprojekti/blob/master/definitionofdone.md)
 
 [Backlog](https://docs.google.com/spreadsheets/d/15L0jkI4aUTAlSz5wAOpp7wbPSEIVxaG1op6_wA98RLQ/edit?usp=sharing)

--- a/src/main/java/ohtu/DaoHelper.java
+++ b/src/main/java/ohtu/DaoHelper.java
@@ -1,0 +1,32 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package ohtu;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+
+/**
+ *
+ * @author lmantyla
+ */
+public class DaoHelper {
+
+    public static void createAndExecuteStatement(String tietokantaosoite, String komento, String... muuttujat) throws Exception {
+        Connection conn = DriverManager.getConnection(tietokantaosoite);
+        PreparedStatement stmt = conn.prepareStatement(komento);
+
+        int luku = 1;
+        while (luku <= muuttujat.length) {
+            stmt.setString(luku, muuttujat[luku - 1]);
+            luku++;
+        }
+
+        stmt.execute();
+        stmt.close();
+        conn.close();
+    }
+}

--- a/src/main/java/ohtu/VideoDao.java
+++ b/src/main/java/ohtu/VideoDao.java
@@ -19,16 +19,9 @@ public class VideoDao {
     public boolean lisaaVideo(String otsikko, String url, String kuvaus) throws Exception {
         if (valid(otsikko, url)) {
             Video video = new Video(otsikko, url, "0", kuvaus);
-            Connection conn = DriverManager.getConnection(tietokantaosoite);
-            PreparedStatement stmt = conn.prepareStatement("INSERT INTO Video(otsikko, url, luettu, kuvaus) "
-                    + "VALUES ( ?, ?, ?, ?)");
-            stmt.setString(1, video.getOtsikko());
-            stmt.setString(2, video.getUrl());
-            stmt.setString(3, video.getLuettu());
-            stmt.setString(4, video.getKuvaus());
-            stmt.execute();
-            stmt.close();
-            conn.close();
+            String komento = "INSERT INTO Video(otsikko, url, luettu, kuvaus) "
+                    + "VALUES ( ?, ?, ?, ?)";
+            DaoHelper.createAndExecuteStatement(tietokantaosoite, komento, video.getOtsikko(), video.getUrl(), video.getLuettu(), video.getKuvaus());
             return true;
         }
         return false;
@@ -86,28 +79,16 @@ public class VideoDao {
 
     public boolean muokkaaVideota(String id, String otsikko, String url, String kuvaus) throws Exception {
         if (valid(otsikko, url)) {
-            Connection conn = DriverManager.getConnection(tietokantaosoite);
-            PreparedStatement stmt = conn.prepareStatement("UPDATE Video SET otsikko = ?, url = ?, kuvaus = ? WHERE id = ? ");
-            stmt.setString(1, otsikko);
-            stmt.setString(2, url);
-            stmt.setString(3, kuvaus);
-            stmt.setString(4, id);
-            stmt.execute();
-            stmt.close();
-            conn.close();
+            String komento = "UPDATE Video SET otsikko = ?, url = ?, kuvaus = ? WHERE id = ? ";
+            DaoHelper.createAndExecuteStatement(tietokantaosoite, komento, otsikko, url, kuvaus, id);
             return true;
         }
         return false;
     }
 
     public void muutaOnkoLuettu(String onkoLuettu, String id) throws Exception {
-        Connection conn = DriverManager.getConnection(tietokantaosoite);
-        PreparedStatement stmt = conn.prepareStatement("UPDATE Video SET luettu = ? WHERE id = ? ");
-        stmt.setString(1, onkoLuettu);
-        stmt.setString(2, id);
-        stmt.execute();
-        stmt.close();
-        conn.close();
+        String komento = "UPDATE Video SET luettu = ? WHERE id = ? ";
+        DaoHelper.createAndExecuteStatement(tietokantaosoite, komento, onkoLuettu, id);
     }
 
     private boolean valid(String otsikko, String url) {


### PR DESCRIPTION
Lisäsin luokan DaoHelper, jossa toteutetaan Dao-luokissa usein lähestulkoon samanlaisena toistuva pätkä, jossa luodaan SQL-komento ja sijoitetaan siihen parametreja. Tämä vähentää toistoa ja helpottaa Dao-luokkien lukemista.

Kun puskin muutoksen ensi kertaa sisään, muutama testi (jotka toimivat lokaalisti) ei mennyt läpi Travisissa. Toisella yrittämällä kaikki menivät läpi.